### PR TITLE
Bypass Untrusted or Self-Signed Certs

### DIFF
--- a/padBuster.pl
+++ b/padBuster.pl
@@ -637,9 +637,11 @@ sub makeRequest {
  do {
   #Quick hack to avoid hostname in URL when using a proxy with SSL (this will get re-set later if needed)
   $ENV{HTTPS_PROXY} = "";
+  $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
   
   $lwp = LWP::UserAgent->new(env_proxy => 1,
                             keep_alive => 1,
+			    ssl_opts => { SSL_verify_mode => 0 },
                             timeout => 30,
 			    requests_redirectable => [],
                             );


### PR DESCRIPTION
Fix to avoid 500 Certificate Verify Failed errors on HTTPS connections to applications with untrusted or self-signed certificates. This is a modification to pull request [#4](https://github.com/GDSSecurity/PadBuster/pull/4).