### PR TITLE
Fixes "Can't locate Crypt/SSLeay.pm" on MacOS

### DIFF
--- a/padBuster.pl
+++ b/padBuster.pl
@@ -19,7 +19,6 @@ use URI::Escape;
 use Getopt::Long;
 use Time::HiRes qw( gettimeofday );
 use Compress::Zlib;
-use Crypt::SSLeay;
 
 # Set defaults with $variable = value
 my $logFiles;


### PR DESCRIPTION
This commit make the script run fine on MacOS Mojave (10.14.6). I haven't tested it with other *nix distros.