### PR TITLE
Initialize $plainTextBytes with an empty string

### DIFF
--- a/padBuster.pl
+++ b/padBuster.pl
@@ -175,7 +175,7 @@ if ($noIv && !$bruteForce && !$plainTextInput) {
 }
 
 # PlainTextBytes is where the complete decrypted sample will be stored (decrypt only)
-my $plainTextBytes;
+my $plainTextBytes = "";
 
 # This is a bool to make sure we know where to replace the sample string
 my $wasSampleFound = 0;


### PR DESCRIPTION
This prevents a warning printed after the first block has been processed:

```
Use of uninitialized value $plainTextBytes in concatenation (.) or
string at padBuster.pl line 361.
```